### PR TITLE
Replace invalid characters for windows

### DIFF
--- a/7zpp/ArchiveExtractCallback.cpp
+++ b/7zpp/ArchiveExtractCallback.cpp
@@ -118,6 +118,19 @@ STDMETHODIMP ArchiveExtractCallback::GetStream( UInt32 index, ISequentialOutStre
 		return ex.Error();
 	}
 
+	// Replace invalid characters
+	for (unsigned iLetter = 0; iLetter < m_relPath.length(); iLetter++)
+	{
+		wchar_t c = m_relPath[iLetter];
+		if (
+			c == ':' || c == '*' || c == '?' || c < 0x20 || c == '<' || c == '>' || c == '|' || c == '"'
+			|| c == '/'
+			|| c == WCHAR_PATH_SEPARATOR)
+		{
+			m_relPath.replace(iLetter, 1, L"_");
+		}
+	}
+
 	// TODO: m_directory could be a relative path
 	m_absPath = FileSys::AppendPath( m_directory, m_relPath );
 


### PR DESCRIPTION
This enables the library to unzip archives whose filenames contain invalid windows characters. For instance an archive containing the file `test<>:?.jpg`. I used the [7z UI code](https://github.com/kornelski/7z/blob/dd4659674b46defa36041e5c11bde2c847823161/CPP/7zip/UI/Common/ExtractingFilePath.cpp#L20) as a reference, all invalid characters are replaced with an underscore `_`, so the file above becomes `test____.jpg`.

I attempted to add a test to the test app but could never get my boost dependencies squared away. So I ended up testing in my UE4 project by just replacing `7zpp_u.lib` in the ZipUtility plugin. Everything is working perfectly for me.


