### PR TITLE
Add support for aborting a zip operation.

### DIFF
--- a/7zpp/ArchiveExtractCallback.h
+++ b/7zpp/ArchiveExtractCallback.h
@@ -5,6 +5,7 @@
 
 #include <7zip/Archive/IArchive.h>
 #include <7zip/IPassword.h>
+#include <7zip/UI/Common/UpdateCallback.h>
 
 #include "ProgressCallback.h"
 
@@ -52,6 +53,9 @@ namespace intl
 		// IProgress
 		STDMETHOD(SetTotal)( UInt64 size );
 		STDMETHOD(SetCompleted)( const UInt64* completeValue );
+		
+		// Early exit, this is not part of any interface
+		STDMETHOD(CheckBreak)();
 
 		// IArchiveExtractCallback
 		STDMETHOD(GetStream)( UInt32 index, ISequentialOutStream** outStream, Int32 askExtractMode );

--- a/7zpp/ArchiveUpdateCallback.cpp
+++ b/7zpp/ArchiveUpdateCallback.cpp
@@ -79,7 +79,7 @@ STDMETHODIMP ArchiveUpdateCallback::SetTotal( UInt64 size )
 	{
 		m_callback->OnStartWithTotal(m_outputPath, size);
 	}
-	return S_OK;
+	return CheckBreak();
 }
 
 STDMETHODIMP ArchiveUpdateCallback::SetCompleted( const UInt64* completeValue )
@@ -87,6 +87,16 @@ STDMETHODIMP ArchiveUpdateCallback::SetCompleted( const UInt64* completeValue )
 	if (m_callback!=nullptr)
 	{
 		m_callback->OnProgress(m_outputPath, *completeValue);
+	}
+	return CheckBreak();
+}
+
+STDMETHODIMP ArchiveUpdateCallback::CheckBreak()
+{
+	if (m_callback != nullptr)
+	{
+		// Abort if OnCheckBreak returns true;
+		return m_callback->OnCheckBreak() ? E_ABORT : S_OK;
 	}
 	return S_OK;
 }
@@ -110,7 +120,7 @@ STDMETHODIMP ArchiveUpdateCallback::GetUpdateItemInfo( UInt32 index, Int32* newD
 		*indexInArchive = static_cast< UInt32 >( -1 ); // TODO: UInt32.Max
 	}
 
-	return S_OK;
+	return CheckBreak();
 }
 
 STDMETHODIMP ArchiveUpdateCallback::GetProperty( UInt32 index, PROPID propID, PROPVARIANT* value )
@@ -167,12 +177,12 @@ STDMETHODIMP ArchiveUpdateCallback::GetStream( UInt32 index, ISequentialInStream
 	CComPtr< InStreamWrapper > wrapperStream = new InStreamWrapper( fileStream );
 	*inStream = wrapperStream.Detach();
 
-	return S_OK;
+	return CheckBreak();
 }
 
 STDMETHODIMP ArchiveUpdateCallback::SetOperationResult( Int32 operationResult )
 {
-	return S_OK;
+	return CheckBreak();
 }
 
 STDMETHODIMP ArchiveUpdateCallback::CryptoGetTextPassword2( Int32* passwordIsDefined, BSTR* password )
@@ -185,7 +195,7 @@ STDMETHODIMP ArchiveUpdateCallback::CryptoGetTextPassword2( Int32* passwordIsDef
 
 STDMETHODIMP ArchiveUpdateCallback::SetRatioInfo( const UInt64* inSize, const UInt64* outSize )
 {
-	return S_OK;
+	return CheckBreak();
 }
 
 }

--- a/7zpp/ArchiveUpdateCallback.h
+++ b/7zpp/ArchiveUpdateCallback.h
@@ -37,6 +37,9 @@ namespace intl
 		STDMETHOD(SetTotal)( UInt64 size );
 		STDMETHOD(SetCompleted)( const UInt64* completeValue );
 
+		// Early exit, this is not part of any interface
+		STDMETHOD(CheckBreak)();
+
 		// IArchiveUpdateCallback
 		STDMETHOD(GetUpdateItemInfo)( UInt32 index, Int32* newData, Int32* newProperties, UInt32* indexInArchive );
 		STDMETHOD(GetProperty)( UInt32 index, PROPID propID, PROPVARIANT* value );

--- a/7zpp/ProgressCallback.h
+++ b/7zpp/ProgressCallback.h
@@ -14,22 +14,27 @@ namespace SevenZip
 		/*
 		Called at beginning
 		*/
-		virtual void OnStartWithTotal(const TString& archivePath, unsigned __int64 totalBytes) {}
+		virtual void OnStartWithTotal(const TString& archivePath, unsigned __int64 totalBytes) = 0;
 
 		/*
 		Called Whenever progress has updated with a bytes complete
 		*/
-		virtual void OnProgress(const TString& archivePath, unsigned __int64 bytesCompleted) {}
+		virtual void OnProgress(const TString& archivePath, unsigned __int64 bytesCompleted) = 0;
 
 
 		/*
 		Called When progress has reached 100%
 		*/
-		virtual void OnDone(const TString& archivePath) {}
+		virtual void OnDone(const TString& archivePath) = 0;
 
 		/*
 		Called When single file progress has reached 100%, returns the filepath that completed
 		*/
-		virtual void OnFileDone(const TString& archivePath, const TString& filePath, unsigned __int64 bytesCompleted) {}
+		virtual void OnFileDone(const TString& archivePath, const TString& filePath, unsigned __int64 bytesCompleted) = 0;
+
+		/*
+		Called to determine if it's time to abort the zip operation. Return true to abort the current operation.
+		*/
+		virtual bool OnCheckBreak() = 0;
 	};
 }


### PR DESCRIPTION
### `ProgressCallback.h` 
Changed to use pure virtual functions to eliminate a compile error on the UE4 library side.

### `ArchiveExtractCallback` / `ArchiveUpdateCallback`
Implementation of `CheckBreak()`. The primary means of allowing zip operations to break is to return `CheckBreak()` in the vast majority of interface callbacks that an archive gets over its lifetime. As to which callbacks should return `CheckBreak()` vs not, this was mostly copied from the SevenZip sample code. I did omit the check from `GetProperty` because it seemed a little overkill and I was also mildly (perhaps without reason) worried about hitting the mutex on the `FThreadSafeBool` too frequently since `GetProperty` seemed high on the most frequently called list.

Since this is COM, returning `E_ABORT` in any of these callbacks effectively terminates the operation. `CheckBreak()` is simply an easy entry point that in-turn calls through to the `ProgressCallback` virtual method `OnCheckBreak()` which is overriden in the UE4 library implementation using an `FThreadSafeBool`.