### PR TITLE
Fix file-rename operations and Allow format detection to fail

### DIFF
--- a/7zpp/ArchiveExtractCallback.cpp
+++ b/7zpp/ArchiveExtractCallback.cpp
@@ -133,9 +133,15 @@ STDMETHODIMP ArchiveExtractCallback::GetStream( UInt32 index, ISequentialOutStre
 	{
 		wchar_t c = m_relPath[iLetter];
 		if (
-			c == ':' || c == '*' || c == '?' || c < 0x20 || c == '<' || c == '>' || c == '|' || c == '"'
-			|| c == '/'
-			|| c == WCHAR_PATH_SEPARATOR)
+			c == ':' 
+			|| c == '*' 
+			|| c == '?' 
+			|| c < 0x20 // printable character range starts at 20
+			|| c == '<' 
+			|| c == '>' 
+			|| c == '|' 
+			|| c == '"'
+			|| c == '/')
 		{
 			m_relPath.replace(iLetter, 1, L"_");
 		}

--- a/7zpp/UsefulFunctions.cpp
+++ b/7zpp/UsefulFunctions.cpp
@@ -248,7 +248,7 @@ namespace SevenZip
 
 		// If you get here, the format is unknown
 		archiveCompressionFormat = CompressionFormat::Unknown;
-		return true;
+		return false;
 	}
 
 	const TString UsefulFunctions::EndingFromCompressionFormat(const CompressionFormatEnum& format)


### PR DESCRIPTION
Finally got the 7zpp-TestApp running and noticed that extraction test 4 was failing. My fault, I was stripping the path seperation character as part of the invalid character check. Fixed that.

I noticed that `DetectCompressionFormat` always returns true, even if the format is undetected at the end, yet there are many places in the UE4 plugin that assume a false state. It now returns false if no format could be detected.