### PR TITLE
Fix GetOrigSizes return incorrect size when archive contains large file

### DIFF
--- a/7zpp/UsefulFunctions.cpp
+++ b/7zpp/UsefulFunctions.cpp
@@ -170,7 +170,7 @@ namespace SevenZip
 					//throw SevenZipException( GetCOMErrMsg( _T( "Open archive" ), hr ) );
 				}
 
-				int size = prop.intVal;
+				auto size = prop.uhVal.QuadPart;
 				origsizes[i] = size_t(size);
 
 				// Get name of file


### PR DESCRIPTION
Fix GetOrigSizes return incorrect size when archive contains large file, use ULARGE_INTEGER to pass size variable.