### PR TITLE
ExtractFileToMemory function missing in include header file

### DIFF
--- a/Include/7zpp/SevenZipExtractor.h
+++ b/Include/7zpp/SevenZipExtractor.h
@@ -20,6 +20,7 @@ namespace SevenZip
 											 const unsigned int numberFiles,
 											 const TString& directory,
 											 ProgressCallback* callback = nullptr);
+		virtual bool ExtractFileToMemory(const unsigned int index, std::vector<BYTE>& out_buffer, ProgressCallback* callback = nullptr);
 
 	private:
 		bool ExtractFilesFromArchive(const CComPtr<IStream>& archiveStream,


### PR DESCRIPTION
This function is used in 7zpp-TestApp, but it is missing in header file at Include directory.